### PR TITLE
Adding try except block for fixing date issue

### DIFF
--- a/pysurveycto/pysurveycto.py
+++ b/pysurveycto/pysurveycto.py
@@ -264,8 +264,13 @@ class SurveyCTOObject(object):
             oldest_completion_date = datetime.datetime.combine(
                 oldest_completion_date, datetime.datetime.min.time()
             )
+        try:
+            date_string = oldest_completion_date.strftime("%b %-d, %Y %-I:%M:%S %p")
+        except ValueError as e:
+            # Except block added for Windows vs Unix format differences
+            date_string = oldest_completion_date.strftime("%b %#d, %Y %#I:%M:%S %p")
 
-        url_date = quote(oldest_completion_date.strftime("%b %-d, %Y %-I:%M:%S %p"))
+        url_date = quote(date_string)
 
         return url_date
 
@@ -336,7 +341,13 @@ class SurveyCTOObject(object):
         self.__check_key_and_raise(key)
 
     def __check_json_extraction_params(
-        self, shape, oldest_completion_date, review_status, repeat_groups, line_breaks, key
+        self,
+        shape,
+        oldest_completion_date,
+        review_status,
+        repeat_groups,
+        line_breaks,
+        key,
     ):
         """
         Check parameters passed for json extraction
@@ -544,7 +555,12 @@ class SurveyCTOObject(object):
 
             # Check params
             self.__check_json_extraction_params(
-                shape, oldest_completion_date, review_status, repeat_groups, line_breaks, key
+                shape,
+                oldest_completion_date,
+                review_status,
+                repeat_groups,
+                line_breaks,
+                key,
             )
 
             data = self.__get_form_data_in_json_format(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = io.open(os.path.join(dir_path, 'README.rst'), encoding='utf-8
 
 setuptools.setup(
     name="pysurveycto",
-    version="0.0.12",
+    version="0.0.13",
     author="Eric Dodge, Jeenu Thomas",
     author_email="it@idinsight.org, Eric.Dodge@idinsight.org, Jeenu.Thomas@idinsight.org",
     description="Interacting with SurveyCTO using Python",


### PR DESCRIPTION
Adding try/except as discussed. 

Confirmed that the following code works on Windows

```
import datetime
from urllib.parse import quote

string_format = "%b %#d, %Y %#I:%M:%S %p"
oldest_completion_date = datetime.datetime(2021, 1, 4, 13, 42, 42)

try:
    date_string = oldest_completion_date.strftime("%b %-d, %Y %-I:%M:%S %p")
except ValueError as e:
    # Except block added for Windows vs Unix format differences
    date_string = oldest_completion_date.strftime("%b %#d, %Y %#I:%M:%S %p")

url_date = quote(date_string)
#'Jan 4, 2021 1:42:42 PM'
```


![image](https://user-images.githubusercontent.com/51594058/144425277-a100ab0f-41a3-456d-bb51-de4198786cd6.png)
