### PR TITLE
Add method to get the currently deployed version number as a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,19 @@ SurveyCTOObject(server_name,
   </p>    
     
 
+*
+  ```python
+  get_deployed_form_version(form_id)
+  ```
+  <p>Fetch version of deployed form from SurveyCTO
+
+    *Parameters:*
+    - **form_id** *(str)*: The form_id of the SurveyCTO form.
+
+    *Returns:* The form version as a string
+  </p>    
+
+
 <a name="usecases"></a>
 # Use Cases
 
@@ -209,6 +222,11 @@ scto = pysurveycto.SurveyCTOObject(server_name, username, password)
   choices_df.to_excel(writer, sheet_name="choices", index=False)
   settings_df.to_excel(writer, sheet_name="settings", index=False)
   writer.save()
+  ```
+
+- Get form version
+  ```python
+  version = scto.get_deployed_form_version(form_id)
   ```
 
 

--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,20 @@ Methods:
   *Returns:* The form definition in JSON format
 
 
+-  
+  .. code:: python
+
+   get_deployed_form_version(form_id)
+
+  Fetch version of deployed form from SurveyCTO
+
+  *Parameters:*
+
+  -  **form\_id** *(str)*: The form\_id of the SurveyCTO form.
+
+  *Returns:* The form version as a string
+
+
 Use Cases
 =========
 
@@ -227,6 +241,11 @@ Use Cases
       choices_df.to_excel(writer, sheet_name="choices", index=False)
       settings_df.to_excel(writer, sheet_name="settings", index=False)
       writer.save()
+
+-  Get form version
+     .. code:: python
+    
+      version = scto.get_deployed_form_version(form_id)
 
 License 
 =======


### PR DESCRIPTION
The package currently has a method to fetch the form definition, which contains the form version number in the "Settings" tab. However, the actual value of the version is not present and instead shows up as a generic Excel formula, from which the actual desired value cannot be derived. It is not clear how to get the static value of the version in the form definition response.

This PR adds a `get_deployed_form_version()` method that pulls the static version number. This is pulled using one of the SurveyCTO web console internal endpoints that is used for populating content on the main console screen. The specific endpoint in question is `/console/forms-groups-datasets/get`.